### PR TITLE
Add basic support for targeting GLSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ OBJ := spirv_cfg.o \
        spirv_glsl.o \
        spirv_hlsl.o \
        spirv_msl.o \
+       crossc-glsl.o \
        crossc-hlsl.o \
        crossc.o
 DEP := $(OBJ:.o=.d)

--- a/crossc-glsl.cc
+++ b/crossc-glsl.cc
@@ -1,0 +1,25 @@
+#include "SPIRV-Cross/spirv_glsl.hpp"
+#include "crossc-priv.h"
+
+crossc_compiler *crossc_glsl_create(const uint32_t *words, size_t word_count)
+{
+	crossc_compiler *comp = new crossc_compiler;
+	try {
+		comp->c = std::make_unique<spirv_cross::CompilerGLSL>(words, word_count);
+	} catch (const std::exception &e) {
+		comp->error = std::string { e.what() };
+	}
+	return comp;
+}
+
+void crossc_glsl_set_version(crossc_compiler *comp, int version,
+                             crossc_glsl_profile profile)
+{
+	if (!comp->c)
+		return;
+	auto glsl = comp->c.get();
+	auto opts = glsl->get_common_options();
+	opts.version = version;
+	opts.es = (profile == CROSSC_GLSL_PROFILE_ES);
+	glsl->set_common_options(opts);
+}

--- a/crossc.h
+++ b/crossc.h
@@ -32,8 +32,24 @@ extern "C" {
 #define CROSSC_VERSION_GET_MINOR(ver) (((ver) >> 16) & 0xff)
 #define CROSSC_VERSION_GET_PATCH(ver) ((ver) & 0xffff)
 
+typedef enum crossc_glsl_profile {
+	CROSSC_GLSL_PROFILE_CORE,
+	CROSSC_GLSL_PROFILE_ES,
+} crossc_glsl_profile;
+
 // Use this to get the version of crossc that has been linked against
 uint32_t crossc_version(void);
+
+// Create a new instance of the compiler targeting GLSL. words should point to
+// a valid SPIR-V binary, which is copied and parsed. After creation,
+// crossc_has_valid_program() should be called to check if the SPIR-V binary
+// was parsed correctly.
+crossc_compiler *crossc_glsl_create(const uint32_t *words, size_t word_count);
+
+// Set the target GLSL version. The format is the same as specified in a
+// #version directive. Profile should be one of the crossc_glsl_profile values.
+void crossc_glsl_set_version(crossc_compiler *comp, int version,
+                             crossc_glsl_profile profile);
 
 // Create a new instance of the compiler targeting HLSL. words should point to
 // a valid SPIR-V binary, which is copied and parsed. After creation,


### PR DESCRIPTION
No configuration options exposed yet, other than setting the version and profile. `crossc_glsl.cc` needs to be added to the sources list in `meson.build` when/if #1 is merged.